### PR TITLE
ENG-304: CLI is capable of updating itself in place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,10 +100,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -106,6 +161,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -135,9 +212,20 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -147,20 +235,33 @@ checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -305,6 +406,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc42b206e70d86ec03285b123e65a5458c92027d1fb2ae3555878b8113b3ddf"
+dependencies = [
+ "console",
+ "number_prefix",
+ "unicode-width",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +487,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,10 +581,17 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 name = "peridio-cli"
 version = "0.1.0"
 dependencies = [
+ "directories",
+ "flate2",
+ "futures-util",
+ "indicatif",
  "peridio-sdk",
+ "reqwest",
+ "serde",
  "serde_json",
  "snafu",
  "structopt",
+ "tar",
  "tokio",
  "tower",
 ]
@@ -538,6 +672,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -640,18 +785,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.139"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.139"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -785,12 +930,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1178,4 +1364,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ snafu = "0.7"
 structopt = "0.3"
 tokio = { version = "1.4", features = ["full"] }
 tower = {version = "0.4"}
+directories = "4.0.1"
+reqwest = {version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"]}
+serde = "1.0.144"
+indicatif = "0.17.0"
+futures-util = "0.3.24"
+flate2 = "1.0.24"
+tar = "0.4.38"

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ fn main() {
         .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!(
-        "cargo:rustc-env=MOREL_VERSION={}-{}",
+        "cargo:rustc-env=MOREL_VERSION={} {}",
         env!("CARGO_PKG_VERSION"),
         git_hash
     );

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 mod signing_keys;
+mod upgrade;
 mod users;
 
 use structopt::StructOpt;
@@ -18,6 +19,8 @@ pub struct Command<T: StructOpt> {
 #[derive(StructOpt, Debug)]
 pub enum ApiCommand {
     SigningKeys(signing_keys::SigningKeysCommand),
+    #[structopt(flatten)]
+    Upgrade(upgrade::UpgradeCommand),
     Users(users::UsersCommand),
 }
 
@@ -26,6 +29,7 @@ impl ApiCommand {
         match self {
             ApiCommand::SigningKeys(cmd) => cmd.run().await?,
             ApiCommand::Users(cmd) => cmd.run().await?,
+            ApiCommand::Upgrade(cmd) => cmd.run().await?,
         };
 
         Ok(())

--- a/src/api/upgrade.rs
+++ b/src/api/upgrade.rs
@@ -1,0 +1,160 @@
+use std::{
+    cmp::min,
+    env,
+    fs::{create_dir_all, rename},
+    io::{Cursor, Seek, SeekFrom, Write},
+    path::Path,
+};
+
+use directories::ProjectDirs;
+use flate2::read::GzDecoder;
+use futures_util::StreamExt;
+use indicatif::{ProgressBar, ProgressStyle};
+use reqwest::ClientBuilder;
+use serde::Deserialize;
+use structopt::StructOpt;
+use tar::Archive;
+
+use crate::Error;
+
+#[derive(Deserialize, Debug)]
+struct GithubAssetResponse {
+    browser_download_url: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct GithubResponse {
+    tag_name: String,
+    assets: Vec<GithubAssetResponse>,
+}
+
+#[derive(StructOpt, Debug)]
+pub enum UpgradeCommand {
+    Upgrade(DoUpgradeCommand),
+}
+
+impl UpgradeCommand {
+    pub async fn run(self) -> Result<(), Error> {
+        match self {
+            Self::Upgrade(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct DoUpgradeCommand {}
+
+impl DoUpgradeCommand {
+    async fn run(self) -> Result<(), Error> {
+        if let Some(proj_dirs) = ProjectDirs::from("com", "peridio", "peridio cli") {
+            let cache_dir = proj_dirs.cache_dir();
+
+            create_dir_all(cache_dir).unwrap();
+
+            if let Ok(resp) = Self::get_latest_release_info().await {
+                let current_version = env!("CARGO_PKG_VERSION");
+                let github_asset_info = resp.assets.first().unwrap();
+
+                // no need to update
+                if resp.tag_name == current_version {
+                    println!("CLI already up to date");
+                    return Ok(());
+                }
+
+                if let Err(message) = Self::download_update(cache_dir, github_asset_info).await {
+                    println!("{}", message);
+                    return Ok(());
+                }
+
+                if let Err(message) = Self::apply_update(cache_dir, &resp) {
+                    println!("{}", message);
+                    return Ok(());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn apply_update(path: &Path, github_response: &GithubResponse) -> Result<(), String> {
+        let update_file = path.join("peridio");
+
+        let current_cli_executable =
+            env::current_exe().map_err(|_| "Can't retrieve the current cli directory")?;
+
+        rename(update_file, current_cli_executable).unwrap();
+
+        println!("CLI upgraded successfully ({})", github_response.tag_name);
+
+        Ok(())
+    }
+
+    async fn download_update(
+        download_path: &Path,
+        github_asset_info: &GithubAssetResponse,
+    ) -> Result<(), String> {
+        let client = ClientBuilder::new().use_rustls_tls().build().unwrap();
+        let url = &github_asset_info.browser_download_url;
+
+        // Reqwest setup
+        let res = client
+            .get(url)
+            .send()
+            .await
+            .map_err(|_| format!("Failed to GET from '{}'", url))?;
+
+        let total_size = res
+            .content_length()
+            .ok_or(format!("Failed to get content length from '{}'", url))?;
+
+        // Indicatif setup
+        let pb = ProgressBar::new(total_size);
+        pb.set_style(ProgressStyle::with_template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec}, {eta})")
+            .unwrap()
+            .progress_chars("#>-"));
+
+        // download chunks
+        let mut downloaded: u64 = 0;
+
+        let mut stream = res.bytes_stream();
+
+        let mem = Vec::new();
+        let mut buff = Cursor::new(mem);
+
+        while let Some(item) = stream.next().await {
+            let chunk = item.map_err(|_| "Error while downloading file".to_string())?;
+            buff.write_all(&chunk)
+                .map_err(|_| "Error while writing to buffer".to_string())?;
+            let new = min(downloaded + (chunk.len() as u64), total_size);
+            downloaded = new;
+            pb.set_position(new);
+        }
+
+        pb.finish_and_clear();
+
+        buff.seek(SeekFrom::Start(0)).unwrap();
+
+        let gz = GzDecoder::new(&mut buff);
+
+        let mut archive = Archive::new(gz);
+
+        archive
+            .unpack(&download_path)
+            .map_err(|_| "Error while saving the updated file".to_string())?;
+
+        Ok(())
+    }
+
+    async fn get_latest_release_info() -> Result<GithubResponse, reqwest::Error> {
+        let client = ClientBuilder::new().use_rustls_tls().build().unwrap();
+
+        client
+            .get("https://api.github.com/repos/peridio/morel/releases/latest")
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "peridio/morel")
+            .send()
+            .await?
+            .json::<GithubResponse>()
+            .await
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ impl fmt::Debug for Error {
 }
 
 #[derive(StructOpt)]
-#[structopt(version = env!("MOREL_VERSION"))]
+#[structopt(name = "peridio", version = env!("MOREL_VERSION"))]
 struct Program {
     #[structopt(subcommand)]
     command: Command,
@@ -59,7 +59,7 @@ impl Program {
 }
 
 #[derive(StructOpt)]
-#[structopt(about = "interact with local or network connected nodes")]
+#[structopt(about = "Work with Peridio from the command line.")]
 enum Command {
     #[structopt(flatten)]
     Api(api::ApiCommand),


### PR DESCRIPTION
Why:

We want to ensure we can upgrade our CLI by getting the latest release from GitHub.

How:

- adding the `upgrade` command, which lets us download the latest release on GitHub
- download the tar.gz in memory and place the file on cache, respecting XDG