### PR TITLE
ENG-467: add firmwares command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,12 +604,13 @@ dependencies = [
  "tar",
  "tokio",
  "tower",
+ "uuid",
 ]
 
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=7a0c59c#7a0c59c9ac4570632de4396b55a61f6b47b0932a"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=405c870#405c870d1918470f44386ab13af8202b4cf264c3"
 dependencies = [
  "chrono",
  "reqwest",
@@ -622,6 +633,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-error"
@@ -666,6 +683,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +753,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -1113,6 +1161,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1218,28 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom",
+ "rand",
+ "uuid-macro-internal",
+]
+
+[[package]]
+name = "uuid-macro-internal"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548f7181a5990efa50237abb7ebca410828b57a8955993334679f8b50b35c97d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "7a0c59c" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "405c870" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"
@@ -20,3 +20,4 @@ indicatif = "0.17.0"
 futures-util = "0.3.24"
 flate2 = "1.0.24"
 tar = "0.4.38"
+uuid = {version = "1.1.2", features = ["v4", "fast-rng", "macro-diagnostics"]}

--- a/src/api/firmwares.rs
+++ b/src/api/firmwares.rs
@@ -1,0 +1,152 @@
+use super::Command;
+use crate::{print_json, ApiSnafu, Error};
+use peridio_sdk::api::firmwares::{
+    CreateFirmwareParams, DeleteFirmwareParams, GetFirmwareParams, ListFirmwareParams,
+};
+use peridio_sdk::api::Api;
+use snafu::ResultExt;
+use structopt::StructOpt;
+use uuid::Uuid;
+
+#[derive(StructOpt, Debug)]
+pub enum FirmwaresCommand {
+    Create(Command<CreateCommand>),
+    Delete(Command<DeleteCommand>),
+    Get(Command<GetCommand>),
+    List(Command<ListCommand>),
+}
+
+impl FirmwaresCommand {
+    pub async fn run(self) -> Result<(), Error> {
+        match self {
+            Self::Create(cmd) => cmd.run().await,
+            Self::Delete(cmd) => cmd.run().await,
+            Self::Get(cmd) => cmd.run().await,
+            Self::List(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct CreateCommand {
+    #[structopt(long)]
+    firmware: Option<String>,
+
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+
+    #[structopt(long)]
+    ttl: Option<u32>,
+}
+
+impl Command<CreateCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = CreateFirmwareParams {
+            firmware: self.inner.firmware,
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+            ttl: self.inner.ttl,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.firmwares().create(params).await.context(ApiSnafu)? {
+            Some(firmware) => print_json!(&firmware),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct DeleteCommand {
+    #[structopt(long)]
+    firmware_uuid: Uuid,
+
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+}
+
+impl Command<DeleteCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = DeleteFirmwareParams {
+            firmware_uuid: self.inner.firmware_uuid.to_string(),
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.firmwares().delete(params).await.context(ApiSnafu)? {
+            Some(_) => panic!(),
+            None => (),
+        };
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct GetCommand {
+    #[structopt(long)]
+    firmware_uuid: Uuid,
+
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+}
+
+impl Command<GetCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = GetFirmwareParams {
+            firmware_uuid: self.inner.firmware_uuid.to_string(),
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.firmwares().get(params).await.context(ApiSnafu)? {
+            Some(firmware) => print_json!(&firmware),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ListCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+}
+
+impl Command<ListCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = ListFirmwareParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.firmwares().list(params).await.context(ApiSnafu)? {
+            Some(firmwares) => print_json!(&firmwares),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,4 @@
+mod firmwares;
 mod signing_keys;
 mod upgrade;
 mod users;
@@ -18,6 +19,7 @@ pub struct Command<T: StructOpt> {
 
 #[derive(StructOpt, Debug)]
 pub enum ApiCommand {
+    Firmwares(firmwares::FirmwaresCommand),
     SigningKeys(signing_keys::SigningKeysCommand),
     #[structopt(flatten)]
     Upgrade(upgrade::UpgradeCommand),
@@ -27,6 +29,7 @@ pub enum ApiCommand {
 impl ApiCommand {
     pub(crate) async fn run(self) -> Result<(), crate::Error> {
         match self {
+            ApiCommand::Firmwares(cmd) => cmd.run().await?,
             ApiCommand::SigningKeys(cmd) => cmd.run().await?,
             ApiCommand::Users(cmd) => cmd.run().await?,
             ApiCommand::Upgrade(cmd) => cmd.run().await?,


### PR DESCRIPTION
Why:

We want to add the CLI logic for the `firmwares` command.

How:

- add `firmwares` related commands
- updated SDK version to support `firmwares`
- added `uuid` library for typing check given values