### PR TITLE
ENG-467: firmware field changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,7 +610,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=8afe567#8afe567c3197a0b9047b0b14f76b9829e5d8ff33"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=90c2378#90c237886e4b4870854aca2a61b53376beeea721"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "8afe567" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "90c2378" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/firmwares.rs
+++ b/src/api/firmwares.rs
@@ -30,7 +30,7 @@ impl FirmwaresCommand {
 #[derive(StructOpt, Debug)]
 pub struct CreateCommand {
     #[structopt(long)]
-    firmware: Option<String>,
+    firmware_path: String,
 
     #[structopt(long)]
     organization_name: String,
@@ -45,7 +45,7 @@ pub struct CreateCommand {
 impl Command<CreateCommand> {
     async fn run(self) -> Result<(), Error> {
         let params = CreateFirmwareParams {
-            firmware: self.inner.firmware,
+            firmware_path: self.inner.firmware_path,
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
             ttl: self.inner.ttl,


### PR DESCRIPTION
Why:

We want to rename `firmware` to `firmware_path` and make the field required