### PR TITLE
ENG-478: improve the UX of upgrading the CLI and account for pre-releases (rc releases)

### DIFF
--- a/.github/workflows/new-build.yml
+++ b/.github/workflows/new-build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   check:
@@ -132,7 +135,7 @@ jobs:
           command: clippy
           args: "-- -D warnings"
   build:
-    if: github.event.pull_request.merged
+    if: github.event_name == "push"
     needs:
       - rustfmt
       - clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,3 +98,4 @@ jobs:
           body_path: CHANGELOG.md
           generate_release_notes: false
           files: peridio-${{ github.ref_name }}_${{ matrix.target }}.tar.gz
+          prerelease: ${{ contains(fromJson('["-rc", "-beta", "-alpha"]'), github.ref) }}


### PR DESCRIPTION
Why:

We want to introduce the `--version` field that allows us to download a specific version.

We also want to mark `RC` releases as prereleases when doing CI/CD.