### PR TITLE
ENG-484: add device-certificates command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 name = "peridio-cli"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "directories",
  "flate2",
  "futures-util",
@@ -610,7 +611,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=9ec6151#9ec6151a381bd15cbaf029fd99c2e72c431549e4"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=25daf71#25daf71e058244db0c9e164b023b9fd38388e529"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "9ec6151" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "25daf71" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"
@@ -21,3 +21,4 @@ futures-util = "0.3.24"
 flate2 = "1.0.24"
 tar = "0.4.38"
 uuid = {version = "1.1.2", features = ["v4", "fast-rng", "macro-diagnostics"]}
+base64 = "0.13.0"

--- a/src/api/device_certificates.rs
+++ b/src/api/device_certificates.rs
@@ -1,0 +1,205 @@
+use std::fs;
+
+use super::Command;
+use crate::{print_json, ApiSnafu, Error};
+use peridio_sdk::api::device_certificates::{
+    CreateDeviceCertificateParams, DeleteDeviceCertificateParams, GetDeviceCertificateParams,
+    ListDeviceCertificateParams,
+};
+use peridio_sdk::api::Api;
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub enum DeviceCertificatesCommand {
+    Create(Command<CreateCommand>),
+    Delete(Command<DeleteCommand>),
+    Get(Command<GetCommand>),
+    List(Command<ListCommand>),
+}
+
+impl DeviceCertificatesCommand {
+    pub async fn run(self) -> Result<(), Error> {
+        match self {
+            Self::Create(cmd) => cmd.run().await,
+            Self::Delete(cmd) => cmd.run().await,
+            Self::Get(cmd) => cmd.run().await,
+            Self::List(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct CreateCommand {
+    #[structopt(long)]
+    device_identifier: String,
+
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+
+    #[structopt(
+        long,
+        conflicts_with("certificate_path"),
+        required_unless_one(&["certificate_path"])
+    )]
+    certificate: Option<String>,
+
+    #[structopt(
+        long,
+        conflicts_with("certificate"),
+        required_unless_one(&["certificate"])
+    )]
+    certificate_path: Option<String>,
+}
+
+impl Command<CreateCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let certificate = if let Some(cert_path) = self.inner.certificate_path {
+            fs::read_to_string(cert_path).unwrap()
+        } else {
+            self.inner.certificate.unwrap()
+        };
+
+        let encoded_certificate = base64::encode(&certificate);
+
+        let params = CreateDeviceCertificateParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+            device_identifier: self.inner.device_identifier,
+            cert: encoded_certificate,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api
+            .device_certificates()
+            .create(params)
+            .await
+            .context(ApiSnafu)?
+        {
+            Some(device_certificate) => print_json!(&device_certificate),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct DeleteCommand {
+    #[structopt(long)]
+    device_identifier: String,
+
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+
+    #[structopt(long)]
+    certificate_serial: String,
+}
+
+impl Command<DeleteCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = DeleteDeviceCertificateParams {
+            device_identifier: self.inner.device_identifier,
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+            certificate_serial: self.inner.certificate_serial,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        if (api
+            .device_certificates()
+            .delete(params)
+            .await
+            .context(ApiSnafu)?)
+        .is_some()
+        {
+            panic!()
+        };
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct GetCommand {
+    #[structopt(long)]
+    device_identifier: String,
+
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+
+    #[structopt(long)]
+    certificate_serial: String,
+}
+
+impl Command<GetCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = GetDeviceCertificateParams {
+            device_identifier: self.inner.device_identifier,
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+            certificate_serial: self.inner.certificate_serial,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api
+            .device_certificates()
+            .get(params)
+            .await
+            .context(ApiSnafu)?
+        {
+            Some(device_certificate) => print_json!(&device_certificate),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ListCommand {
+    #[structopt(long)]
+    device_identifier: String,
+
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+}
+
+impl Command<ListCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = ListDeviceCertificateParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+            device_identifier: self.inner.device_identifier,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api
+            .device_certificates()
+            .list(params)
+            .await
+            .context(ApiSnafu)?
+        {
+            Some(device_certificate) => print_json!(&device_certificate),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}

--- a/src/api/devices.rs
+++ b/src/api/devices.rs
@@ -247,11 +247,12 @@ impl Command<AuthenticateCommand> {
         } else {
             self.inner.certificate.unwrap()
         };
+        let encoded_certificate = base64::encode(&certificate);
 
         let params = AuthenticateDeviceParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
-            certificate,
+            certificate: encoded_certificate,
         };
 
         let api = Api::new(self.api_key, self.base_url);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,6 +1,8 @@
 mod deployments;
+mod device_certificates;
 mod devices;
 mod firmwares;
+mod products;
 mod signing_keys;
 mod upgrade;
 mod users;
@@ -23,7 +25,9 @@ pub struct Command<T: StructOpt> {
 pub enum ApiCommand {
     Deployments(deployments::DeploymentsCommand),
     Devices(devices::DevicesCommand),
+    DeviceCertificates(device_certificates::DeviceCertificatesCommand),
     Firmwares(firmwares::FirmwaresCommand),
+    Products(products::ProductsCommand),
     SigningKeys(signing_keys::SigningKeysCommand),
     #[structopt(flatten)]
     Upgrade(upgrade::UpgradeCommand),
@@ -35,7 +39,9 @@ impl ApiCommand {
         match self {
             ApiCommand::Deployments(cmd) => cmd.run().await?,
             ApiCommand::Devices(cmd) => cmd.run().await?,
+            ApiCommand::DeviceCertificates(cmd) => cmd.run().await?,
             ApiCommand::Firmwares(cmd) => cmd.run().await?,
+            ApiCommand::Products(cmd) => cmd.run().await?,
             ApiCommand::SigningKeys(cmd) => cmd.run().await?,
             ApiCommand::Users(cmd) => cmd.run().await?,
             ApiCommand::Upgrade(cmd) => cmd.run().await?,

--- a/src/api/products.rs
+++ b/src/api/products.rs
@@ -1,0 +1,174 @@
+use super::Command;
+use crate::{print_json, ApiSnafu, Error};
+use peridio_sdk::api::products::{
+    CreateProductParams, DeleteProductParams, GetProductParams, ListProductParams,
+    UpdateProductParams,
+};
+use peridio_sdk::api::{Api, UpdateProduct};
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub enum ProductsCommand {
+    Create(Command<CreateCommand>),
+    Delete(Command<DeleteCommand>),
+    Get(Command<GetCommand>),
+    List(Command<ListCommand>),
+    Update(Command<UpdateCommand>),
+}
+
+impl ProductsCommand {
+    pub async fn run(self) -> Result<(), Error> {
+        match self {
+            Self::Create(cmd) => cmd.run().await,
+            Self::Delete(cmd) => cmd.run().await,
+            Self::Get(cmd) => cmd.run().await,
+            Self::List(cmd) => cmd.run().await,
+            Self::Update(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct CreateCommand {
+    #[structopt(long)]
+    delta_updatable: Option<bool>,
+
+    #[structopt(long)]
+    name: String,
+
+    #[structopt(long)]
+    organization_name: String,
+}
+
+impl Command<CreateCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = CreateProductParams {
+            organization_name: self.inner.organization_name,
+            name: self.inner.name,
+            delta_updatable: self.inner.delta_updatable,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.products().create(params).await.context(ApiSnafu)? {
+            Some(product) => print_json!(&product),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct DeleteCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+}
+
+impl Command<DeleteCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = DeleteProductParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        if (api.products().delete(params).await.context(ApiSnafu)?).is_some() {
+            panic!()
+        };
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct GetCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+}
+
+impl Command<GetCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = GetProductParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.products().get(params).await.context(ApiSnafu)? {
+            Some(product) => print_json!(&product),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ListCommand {
+    #[structopt(long)]
+    organization_name: String,
+}
+
+impl Command<ListCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = ListProductParams {
+            organization_name: self.inner.organization_name,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.products().list(params).await.context(ApiSnafu)? {
+            Some(product) => print_json!(&product),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct UpdateCommand {
+    #[structopt(long)]
+    delta_updatable: Option<bool>,
+
+    #[structopt(long)]
+    name: Option<String>,
+
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+}
+
+impl Command<UpdateCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = UpdateProductParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+            product: UpdateProduct {
+                delta_updatable: self.inner.delta_updatable,
+                name: self.inner.name,
+            },
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.products().update(params).await.context(ApiSnafu)? {
+            Some(product) => print_json!(&product),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Related: #ENG-471 

Why:

We want to add `device-certificates` and `products` support to our CLI.

Notable changes:

- added base64 library
- encode certificate to base64 during `devices authentication`