### PR TITLE
ENG-487: add CLI commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=25daf71#25daf71e058244db0c9e164b023b9fd38388e529"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=0600c91#0600c914c78a57a73ce68cef6c25024070701025"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "25daf71" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "0600c91" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,6 +2,8 @@ mod deployments;
 mod device_certificates;
 mod devices;
 mod firmwares;
+mod organization_users;
+mod product_users;
 mod products;
 mod signing_keys;
 mod upgrade;
@@ -27,7 +29,9 @@ pub enum ApiCommand {
     Devices(devices::DevicesCommand),
     DeviceCertificates(device_certificates::DeviceCertificatesCommand),
     Firmwares(firmwares::FirmwaresCommand),
+    OrganizationUsers(organization_users::OrganizationUsersCommand),
     Products(products::ProductsCommand),
+    ProductUsers(product_users::ProductUsersCommand),
     SigningKeys(signing_keys::SigningKeysCommand),
     #[structopt(flatten)]
     Upgrade(upgrade::UpgradeCommand),
@@ -41,7 +45,9 @@ impl ApiCommand {
             ApiCommand::Devices(cmd) => cmd.run().await?,
             ApiCommand::DeviceCertificates(cmd) => cmd.run().await?,
             ApiCommand::Firmwares(cmd) => cmd.run().await?,
+            ApiCommand::OrganizationUsers(cmd) => cmd.run().await?,
             ApiCommand::Products(cmd) => cmd.run().await?,
+            ApiCommand::ProductUsers(cmd) => cmd.run().await?,
             ApiCommand::SigningKeys(cmd) => cmd.run().await?,
             ApiCommand::Users(cmd) => cmd.run().await?,
             ApiCommand::Upgrade(cmd) => cmd.run().await?,

--- a/src/api/organization_users.rs
+++ b/src/api/organization_users.rs
@@ -1,0 +1,194 @@
+use super::Command;
+use crate::{print_json, ApiSnafu, Error};
+use peridio_sdk::api::organization_users::{
+    CreateOrganizationUserParams, DeleteOrganizationUserParams, GetOrganizationUserParams,
+    ListOrganizationUserParams, UpdateOrganizationUserParams,
+};
+use peridio_sdk::api::Api;
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub enum OrganizationUsersCommand {
+    Add(Command<AddCommand>),
+    Delete(Command<DeleteCommand>),
+    Get(Command<GetCommand>),
+    List(Command<ListCommand>),
+    Update(Command<UpdateCommand>),
+}
+
+impl OrganizationUsersCommand {
+    pub async fn run(self) -> Result<(), Error> {
+        match self {
+            Self::Add(cmd) => cmd.run().await,
+            Self::Delete(cmd) => cmd.run().await,
+            Self::Get(cmd) => cmd.run().await,
+            Self::List(cmd) => cmd.run().await,
+            Self::Update(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct AddCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    role: String,
+
+    #[structopt(long)]
+    username: String,
+}
+
+impl Command<AddCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = CreateOrganizationUserParams {
+            organization_name: self.inner.organization_name,
+            role: self.inner.role,
+            username: self.inner.username,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api
+            .organization_users()
+            .create(params)
+            .await
+            .context(ApiSnafu)?
+        {
+            Some(device) => print_json!(&device),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct DeleteCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    user_username: String,
+}
+
+impl Command<DeleteCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = DeleteOrganizationUserParams {
+            organization_name: self.inner.organization_name,
+            user_username: self.inner.user_username,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        if (api
+            .organization_users()
+            .delete(params)
+            .await
+            .context(ApiSnafu)?)
+        .is_some()
+        {
+            panic!()
+        };
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct GetCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    user_username: String,
+}
+
+impl Command<GetCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = GetOrganizationUserParams {
+            organization_name: self.inner.organization_name,
+            user_username: self.inner.user_username,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api
+            .organization_users()
+            .get(params)
+            .await
+            .context(ApiSnafu)?
+        {
+            Some(device) => print_json!(&device),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ListCommand {
+    #[structopt(long)]
+    organization_name: String,
+}
+
+impl Command<ListCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = ListOrganizationUserParams {
+            organization_name: self.inner.organization_name,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api
+            .organization_users()
+            .list(params)
+            .await
+            .context(ApiSnafu)?
+        {
+            Some(devices) => print_json!(&devices),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct UpdateCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    role: String,
+
+    #[structopt(long)]
+    user_username: String,
+}
+
+impl Command<UpdateCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = UpdateOrganizationUserParams {
+            organization_name: self.inner.organization_name,
+            role: self.inner.role,
+            user_username: self.inner.user_username,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api
+            .organization_users()
+            .update(params)
+            .await
+            .context(ApiSnafu)?
+        {
+            Some(device) => print_json!(&device),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}

--- a/src/api/product_users.rs
+++ b/src/api/product_users.rs
@@ -1,0 +1,188 @@
+use super::Command;
+use crate::{print_json, ApiSnafu, Error};
+use peridio_sdk::api::product_users::{
+    AddProductUserParams, DeleteProductUserParams, GetProductUserParams, ListProductUserParams,
+    UpdateProductUserParams,
+};
+use peridio_sdk::api::Api;
+use snafu::ResultExt;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub enum ProductUsersCommand {
+    Add(Command<AddCommand>),
+    Delete(Command<DeleteCommand>),
+    Get(Command<GetCommand>),
+    List(Command<ListCommand>),
+    Update(Command<UpdateCommand>),
+}
+
+impl ProductUsersCommand {
+    pub async fn run(self) -> Result<(), Error> {
+        match self {
+            Self::Add(cmd) => cmd.run().await,
+            Self::Delete(cmd) => cmd.run().await,
+            Self::Get(cmd) => cmd.run().await,
+            Self::List(cmd) => cmd.run().await,
+            Self::Update(cmd) => cmd.run().await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct AddCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+
+    #[structopt(long)]
+    role: String,
+
+    #[structopt(long)]
+    username: String,
+}
+
+impl Command<AddCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = AddProductUserParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+            role: self.inner.role,
+            username: self.inner.username,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.product_users().add(params).await.context(ApiSnafu)? {
+            Some(device) => print_json!(&device),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct DeleteCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+
+    #[structopt(long)]
+    user_username: String,
+}
+
+impl Command<DeleteCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = DeleteProductUserParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+            user_username: self.inner.user_username,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        if (api.product_users().delete(params).await.context(ApiSnafu)?).is_some() {
+            panic!()
+        };
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct GetCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+
+    #[structopt(long)]
+    user_username: String,
+}
+
+impl Command<GetCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = GetProductUserParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+            user_username: self.inner.user_username,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.product_users().get(params).await.context(ApiSnafu)? {
+            Some(device) => print_json!(&device),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct ListCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+}
+
+impl Command<ListCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = ListProductUserParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.product_users().list(params).await.context(ApiSnafu)? {
+            Some(devices) => print_json!(&devices),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub struct UpdateCommand {
+    #[structopt(long)]
+    organization_name: String,
+
+    #[structopt(long)]
+    product_name: String,
+
+    #[structopt(long)]
+    role: String,
+
+    #[structopt(long)]
+    user_username: String,
+}
+
+impl Command<UpdateCommand> {
+    async fn run(self) -> Result<(), Error> {
+        let params = UpdateProductUserParams {
+            organization_name: self.inner.organization_name,
+            product_name: self.inner.product_name,
+            role: self.inner.role,
+            user_username: self.inner.user_username,
+        };
+
+        let api = Api::new(self.api_key, self.base_url);
+
+        match api.product_users().update(params).await.context(ApiSnafu)? {
+            Some(device) => print_json!(&device),
+            None => panic!(),
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Why:

We want to add support for `organization-users` and `product-users` to our CLI.

Notes:

`organization-users create` command renamed to `organization-users add` following server guidelines