### PR TITLE
ENG-491: fix inconsistencies in our CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=0600c91#0600c914c78a57a73ce68cef6c25024070701025"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=b26b33d#b26b33ddf76e7a5d9d4cc754e4d32e3e88459168"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "0600c91" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "b26b33d" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/devices.rs
+++ b/src/api/devices.rs
@@ -3,8 +3,8 @@ use std::fs;
 use super::Command;
 use crate::{print_json, ApiSnafu, Error};
 use peridio_sdk::api::devices::{
-    AuthenticateDeviceParams, CreateDevice, CreateDeviceParams, DeleteDeviceParams,
-    GetDeviceParams, ListDeviceParams, UpdateDeviceParams,
+    AuthenticateDeviceParams, CreateDeviceParams, DeleteDeviceParams, GetDeviceParams,
+    ListDeviceParams, UpdateDeviceParams,
 };
 use peridio_sdk::api::Api;
 use snafu::ResultExt;
@@ -36,16 +36,16 @@ impl DevicesCommand {
 #[derive(StructOpt, Debug)]
 pub struct CreateCommand {
     #[structopt(long)]
-    description: String,
+    description: Option<String>,
 
     #[structopt(long)]
-    healthy: bool,
+    healthy: Option<bool>,
 
     #[structopt(long)]
     identifier: String,
 
     #[structopt(long)]
-    last_communication: String,
+    last_communication: Option<String>,
 
     #[structopt(long)]
     organization_name: String,
@@ -54,7 +54,7 @@ pub struct CreateCommand {
     product_name: String,
 
     #[structopt(long, required = true)]
-    tags: Vec<String>,
+    tags: Option<Vec<String>>,
 }
 
 impl Command<CreateCommand> {
@@ -62,13 +62,11 @@ impl Command<CreateCommand> {
         let params = CreateDeviceParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
-            data: CreateDevice {
-                description: self.inner.description,
-                healthy: self.inner.healthy,
-                identifier: self.inner.identifier,
-                last_communication: self.inner.last_communication,
-                tags: self.inner.tags,
-            },
+            description: self.inner.description,
+            healthy: self.inner.healthy,
+            identifier: self.inner.identifier,
+            last_communication: self.inner.last_communication,
+            tags: self.inner.tags,
         };
 
         let api = Api::new(self.api_key, self.base_url);

--- a/src/api/organization_users.rs
+++ b/src/api/organization_users.rs
@@ -1,8 +1,8 @@
 use super::Command;
 use crate::{print_json, ApiSnafu, Error};
 use peridio_sdk::api::organization_users::{
-    CreateOrganizationUserParams, DeleteOrganizationUserParams, GetOrganizationUserParams,
-    ListOrganizationUserParams, UpdateOrganizationUserParams,
+    AddOrganizationUserParams, GetOrganizationUserParams, ListOrganizationUserParams,
+    RemoveOrganizationUserParams, UpdateOrganizationUserParams,
 };
 use peridio_sdk::api::Api;
 use snafu::ResultExt;
@@ -11,7 +11,7 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 pub enum OrganizationUsersCommand {
     Add(Command<AddCommand>),
-    Delete(Command<DeleteCommand>),
+    Remove(Command<RemoveCommand>),
     Get(Command<GetCommand>),
     List(Command<ListCommand>),
     Update(Command<UpdateCommand>),
@@ -21,7 +21,7 @@ impl OrganizationUsersCommand {
     pub async fn run(self) -> Result<(), Error> {
         match self {
             Self::Add(cmd) => cmd.run().await,
-            Self::Delete(cmd) => cmd.run().await,
+            Self::Remove(cmd) => cmd.run().await,
             Self::Get(cmd) => cmd.run().await,
             Self::List(cmd) => cmd.run().await,
             Self::Update(cmd) => cmd.run().await,
@@ -43,7 +43,7 @@ pub struct AddCommand {
 
 impl Command<AddCommand> {
     async fn run(self) -> Result<(), Error> {
-        let params = CreateOrganizationUserParams {
+        let params = AddOrganizationUserParams {
             organization_name: self.inner.organization_name,
             role: self.inner.role,
             username: self.inner.username,
@@ -53,7 +53,7 @@ impl Command<AddCommand> {
 
         match api
             .organization_users()
-            .create(params)
+            .add(params)
             .await
             .context(ApiSnafu)?
         {
@@ -66,7 +66,7 @@ impl Command<AddCommand> {
 }
 
 #[derive(StructOpt, Debug)]
-pub struct DeleteCommand {
+pub struct RemoveCommand {
     #[structopt(long)]
     organization_name: String,
 
@@ -74,9 +74,9 @@ pub struct DeleteCommand {
     user_username: String,
 }
 
-impl Command<DeleteCommand> {
+impl Command<RemoveCommand> {
     async fn run(self) -> Result<(), Error> {
-        let params = DeleteOrganizationUserParams {
+        let params = RemoveOrganizationUserParams {
             organization_name: self.inner.organization_name,
             user_username: self.inner.user_username,
         };
@@ -85,7 +85,7 @@ impl Command<DeleteCommand> {
 
         if (api
             .organization_users()
-            .delete(params)
+            .remove(params)
             .await
             .context(ApiSnafu)?)
         .is_some()

--- a/src/api/product_users.rs
+++ b/src/api/product_users.rs
@@ -1,7 +1,7 @@
 use super::Command;
 use crate::{print_json, ApiSnafu, Error};
 use peridio_sdk::api::product_users::{
-    AddProductUserParams, DeleteProductUserParams, GetProductUserParams, ListProductUserParams,
+    AddProductUserParams, GetProductUserParams, ListProductUserParams, RemoveProductUserParams,
     UpdateProductUserParams,
 };
 use peridio_sdk::api::Api;
@@ -11,7 +11,7 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 pub enum ProductUsersCommand {
     Add(Command<AddCommand>),
-    Delete(Command<DeleteCommand>),
+    Remove(Command<RemoveCommand>),
     Get(Command<GetCommand>),
     List(Command<ListCommand>),
     Update(Command<UpdateCommand>),
@@ -21,7 +21,7 @@ impl ProductUsersCommand {
     pub async fn run(self) -> Result<(), Error> {
         match self {
             Self::Add(cmd) => cmd.run().await,
-            Self::Delete(cmd) => cmd.run().await,
+            Self::Remove(cmd) => cmd.run().await,
             Self::Get(cmd) => cmd.run().await,
             Self::List(cmd) => cmd.run().await,
             Self::Update(cmd) => cmd.run().await,
@@ -65,7 +65,7 @@ impl Command<AddCommand> {
 }
 
 #[derive(StructOpt, Debug)]
-pub struct DeleteCommand {
+pub struct RemoveCommand {
     #[structopt(long)]
     organization_name: String,
 
@@ -76,9 +76,9 @@ pub struct DeleteCommand {
     user_username: String,
 }
 
-impl Command<DeleteCommand> {
+impl Command<RemoveCommand> {
     async fn run(self) -> Result<(), Error> {
-        let params = DeleteProductUserParams {
+        let params = RemoveProductUserParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
             user_username: self.inner.user_username,
@@ -86,7 +86,7 @@ impl Command<DeleteCommand> {
 
         let api = Api::new(self.api_key, self.base_url);
 
-        if (api.product_users().delete(params).await.context(ApiSnafu)?).is_some() {
+        if (api.product_users().remove(params).await.context(ApiSnafu)?).is_some() {
             panic!()
         };
 


### PR DESCRIPTION
Related: ENG-496

Why:

We want to fix inconsistencies between our SDK, the API, the CLI, and the documentation.

How:

- fix device CLI inconsistencies
- fix organization-users CLI inconsistencies
- fix product-users CLI inconsistencies