### PR TITLE
ENG-492: improve UX for non-2xx responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=b26b33d#b26b33ddf76e7a5d9d4cc754e4d32e3e88459168"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=da7ca67#da7ca6753b9a8f5219157d2e82b1b5f0922ed3d0"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "b26b33d" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "da7ca67" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"


### PR DESCRIPTION
Why:

We want to handle `500`, `409`, and `422` status code errors in our SDK.