### PR TITLE
ENG-503: move global options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=626c959#626c95984ce0627e454ea16c0b20adbd1ca73547"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=5f0a556#5f0a55649b29571f7a55dbb6853318dca935c20e"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "626c959" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "5f0a556" }
 serde_json = "1.0"
 snafu = "0.7"
 structopt = "0.3"

--- a/src/api/device_certificates.rs
+++ b/src/api/device_certificates.rs
@@ -1,12 +1,16 @@
 use std::fs;
 
 use super::Command;
-use crate::{print_json, ApiSnafu, Error};
+use crate::print_json;
+use crate::ApiSnafu;
+use crate::Error;
+use crate::GlobalOptions;
 use peridio_sdk::api::device_certificates::{
     CreateDeviceCertificateParams, DeleteDeviceCertificateParams, GetDeviceCertificateParams,
     ListDeviceCertificateParams,
 };
 use peridio_sdk::api::Api;
+use peridio_sdk::api::ApiOptions;
 use snafu::ResultExt;
 use structopt::StructOpt;
 
@@ -19,12 +23,12 @@ pub enum DeviceCertificatesCommand {
 }
 
 impl DeviceCertificatesCommand {
-    pub async fn run(self) -> Result<(), Error> {
+    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         match self {
-            Self::Create(cmd) => cmd.run().await,
-            Self::Delete(cmd) => cmd.run().await,
-            Self::Get(cmd) => cmd.run().await,
-            Self::List(cmd) => cmd.run().await,
+            Self::Create(cmd) => cmd.run(global_options).await,
+            Self::Delete(cmd) => cmd.run(global_options).await,
+            Self::Get(cmd) => cmd.run(global_options).await,
+            Self::List(cmd) => cmd.run(global_options).await,
         }
     }
 }
@@ -56,7 +60,7 @@ pub struct CreateCommand {
 }
 
 impl Command<CreateCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let certificate = if let Some(cert_path) = self.inner.certificate_path {
             fs::read_to_string(cert_path).unwrap()
         } else {
@@ -72,7 +76,10 @@ impl Command<CreateCommand> {
             cert: encoded_certificate,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api
             .device_certificates()
@@ -104,7 +111,7 @@ pub struct DeleteCommand {
 }
 
 impl Command<DeleteCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = DeleteDeviceCertificateParams {
             device_identifier: self.inner.device_identifier,
             organization_name: self.inner.organization_name,
@@ -112,7 +119,10 @@ impl Command<DeleteCommand> {
             certificate_serial: self.inner.certificate_serial,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         if (api
             .device_certificates()
@@ -144,7 +154,7 @@ pub struct GetCommand {
 }
 
 impl Command<GetCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = GetDeviceCertificateParams {
             device_identifier: self.inner.device_identifier,
             organization_name: self.inner.organization_name,
@@ -152,7 +162,10 @@ impl Command<GetCommand> {
             certificate_serial: self.inner.certificate_serial,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api
             .device_certificates()
@@ -181,14 +194,17 @@ pub struct ListCommand {
 }
 
 impl Command<ListCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = ListDeviceCertificateParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
             device_identifier: self.inner.device_identifier,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api
             .device_certificates()

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,16 +9,11 @@ mod signing_keys;
 mod upgrade;
 mod users;
 
+use crate::GlobalOptions;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 pub struct Command<T: StructOpt> {
-    #[structopt(long, env = "PERIDIO_API_KEY")]
-    pub api_key: String,
-
-    #[structopt(long, env = "PERIDIO_BASE_URL")]
-    pub base_url: Option<String>,
-
     #[structopt(flatten)]
     inner: T,
 }
@@ -39,17 +34,17 @@ pub enum ApiCommand {
 }
 
 impl ApiCommand {
-    pub(crate) async fn run(self) -> Result<(), crate::Error> {
+    pub(crate) async fn run(self, global_options: GlobalOptions) -> Result<(), crate::Error> {
         match self {
-            ApiCommand::Deployments(cmd) => cmd.run().await?,
-            ApiCommand::Devices(cmd) => cmd.run().await?,
-            ApiCommand::DeviceCertificates(cmd) => cmd.run().await?,
-            ApiCommand::Firmwares(cmd) => cmd.run().await?,
-            ApiCommand::OrganizationUsers(cmd) => cmd.run().await?,
-            ApiCommand::Products(cmd) => cmd.run().await?,
-            ApiCommand::ProductUsers(cmd) => cmd.run().await?,
-            ApiCommand::SigningKeys(cmd) => cmd.run().await?,
-            ApiCommand::Users(cmd) => cmd.run().await?,
+            ApiCommand::Deployments(cmd) => cmd.run(global_options).await?,
+            ApiCommand::Devices(cmd) => cmd.run(global_options).await?,
+            ApiCommand::DeviceCertificates(cmd) => cmd.run(global_options).await?,
+            ApiCommand::Firmwares(cmd) => cmd.run(global_options).await?,
+            ApiCommand::OrganizationUsers(cmd) => cmd.run(global_options).await?,
+            ApiCommand::Products(cmd) => cmd.run(global_options).await?,
+            ApiCommand::ProductUsers(cmd) => cmd.run(global_options).await?,
+            ApiCommand::SigningKeys(cmd) => cmd.run(global_options).await?,
+            ApiCommand::Users(cmd) => cmd.run(global_options).await?,
             ApiCommand::Upgrade(cmd) => cmd.run().await?,
         };
 

--- a/src/api/organization_users.rs
+++ b/src/api/organization_users.rs
@@ -1,10 +1,14 @@
 use super::Command;
-use crate::{print_json, ApiSnafu, Error};
+use crate::print_json;
+use crate::ApiSnafu;
+use crate::Error;
+use crate::GlobalOptions;
 use peridio_sdk::api::organization_users::{
     AddOrganizationUserParams, GetOrganizationUserParams, ListOrganizationUserParams,
     RemoveOrganizationUserParams, UpdateOrganizationUserParams,
 };
 use peridio_sdk::api::Api;
+use peridio_sdk::api::ApiOptions;
 use snafu::ResultExt;
 use structopt::StructOpt;
 
@@ -18,13 +22,13 @@ pub enum OrganizationUsersCommand {
 }
 
 impl OrganizationUsersCommand {
-    pub async fn run(self) -> Result<(), Error> {
+    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         match self {
-            Self::Add(cmd) => cmd.run().await,
-            Self::Remove(cmd) => cmd.run().await,
-            Self::Get(cmd) => cmd.run().await,
-            Self::List(cmd) => cmd.run().await,
-            Self::Update(cmd) => cmd.run().await,
+            Self::Add(cmd) => cmd.run(global_options).await,
+            Self::Remove(cmd) => cmd.run(global_options).await,
+            Self::Get(cmd) => cmd.run(global_options).await,
+            Self::List(cmd) => cmd.run(global_options).await,
+            Self::Update(cmd) => cmd.run(global_options).await,
         }
     }
 }
@@ -42,14 +46,17 @@ pub struct AddCommand {
 }
 
 impl Command<AddCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = AddOrganizationUserParams {
             organization_name: self.inner.organization_name,
             role: self.inner.role,
             username: self.inner.username,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api
             .organization_users()
@@ -75,13 +82,16 @@ pub struct RemoveCommand {
 }
 
 impl Command<RemoveCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = RemoveOrganizationUserParams {
             organization_name: self.inner.organization_name,
             user_username: self.inner.user_username,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         if (api
             .organization_users()
@@ -107,13 +117,16 @@ pub struct GetCommand {
 }
 
 impl Command<GetCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = GetOrganizationUserParams {
             organization_name: self.inner.organization_name,
             user_username: self.inner.user_username,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api
             .organization_users()
@@ -136,12 +149,15 @@ pub struct ListCommand {
 }
 
 impl Command<ListCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = ListOrganizationUserParams {
             organization_name: self.inner.organization_name,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api
             .organization_users()
@@ -170,14 +186,17 @@ pub struct UpdateCommand {
 }
 
 impl Command<UpdateCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = UpdateOrganizationUserParams {
             organization_name: self.inner.organization_name,
             role: self.inner.role,
             user_username: self.inner.user_username,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api
             .organization_users()

--- a/src/api/product_users.rs
+++ b/src/api/product_users.rs
@@ -1,10 +1,14 @@
 use super::Command;
-use crate::{print_json, ApiSnafu, Error};
+use crate::print_json;
+use crate::ApiSnafu;
+use crate::Error;
+use crate::GlobalOptions;
 use peridio_sdk::api::product_users::{
     AddProductUserParams, GetProductUserParams, ListProductUserParams, RemoveProductUserParams,
     UpdateProductUserParams,
 };
 use peridio_sdk::api::Api;
+use peridio_sdk::api::ApiOptions;
 use snafu::ResultExt;
 use structopt::StructOpt;
 
@@ -18,13 +22,13 @@ pub enum ProductUsersCommand {
 }
 
 impl ProductUsersCommand {
-    pub async fn run(self) -> Result<(), Error> {
+    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         match self {
-            Self::Add(cmd) => cmd.run().await,
-            Self::Remove(cmd) => cmd.run().await,
-            Self::Get(cmd) => cmd.run().await,
-            Self::List(cmd) => cmd.run().await,
-            Self::Update(cmd) => cmd.run().await,
+            Self::Add(cmd) => cmd.run(global_options).await,
+            Self::Remove(cmd) => cmd.run(global_options).await,
+            Self::Get(cmd) => cmd.run(global_options).await,
+            Self::List(cmd) => cmd.run(global_options).await,
+            Self::Update(cmd) => cmd.run(global_options).await,
         }
     }
 }
@@ -45,7 +49,7 @@ pub struct AddCommand {
 }
 
 impl Command<AddCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = AddProductUserParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
@@ -53,7 +57,10 @@ impl Command<AddCommand> {
             username: self.inner.username,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api.product_users().add(params).await.context(ApiSnafu)? {
             Some(device) => print_json!(&device),
@@ -77,14 +84,17 @@ pub struct RemoveCommand {
 }
 
 impl Command<RemoveCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = RemoveProductUserParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
             user_username: self.inner.user_username,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         if (api.product_users().remove(params).await.context(ApiSnafu)?).is_some() {
             panic!()
@@ -107,14 +117,17 @@ pub struct GetCommand {
 }
 
 impl Command<GetCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = GetProductUserParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
             user_username: self.inner.user_username,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api.product_users().get(params).await.context(ApiSnafu)? {
             Some(device) => print_json!(&device),
@@ -135,13 +148,16 @@ pub struct ListCommand {
 }
 
 impl Command<ListCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = ListProductUserParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api.product_users().list(params).await.context(ApiSnafu)? {
             Some(devices) => print_json!(&devices),
@@ -168,7 +184,7 @@ pub struct UpdateCommand {
 }
 
 impl Command<UpdateCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = UpdateProductUserParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
@@ -176,7 +192,10 @@ impl Command<UpdateCommand> {
             user_username: self.inner.user_username,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api.product_users().update(params).await.context(ApiSnafu)? {
             Some(device) => print_json!(&device),

--- a/src/api/products.rs
+++ b/src/api/products.rs
@@ -1,10 +1,15 @@
 use super::Command;
-use crate::{print_json, ApiSnafu, Error};
+use crate::print_json;
+use crate::ApiSnafu;
+use crate::Error;
+use crate::GlobalOptions;
 use peridio_sdk::api::products::{
     CreateProductParams, DeleteProductParams, GetProductParams, ListProductParams,
     UpdateProductParams,
 };
-use peridio_sdk::api::{Api, UpdateProduct};
+use peridio_sdk::api::Api;
+use peridio_sdk::api::ApiOptions;
+use peridio_sdk::api::UpdateProduct;
 use snafu::ResultExt;
 use structopt::StructOpt;
 
@@ -18,13 +23,13 @@ pub enum ProductsCommand {
 }
 
 impl ProductsCommand {
-    pub async fn run(self) -> Result<(), Error> {
+    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         match self {
-            Self::Create(cmd) => cmd.run().await,
-            Self::Delete(cmd) => cmd.run().await,
-            Self::Get(cmd) => cmd.run().await,
-            Self::List(cmd) => cmd.run().await,
-            Self::Update(cmd) => cmd.run().await,
+            Self::Create(cmd) => cmd.run(global_options).await,
+            Self::Delete(cmd) => cmd.run(global_options).await,
+            Self::Get(cmd) => cmd.run(global_options).await,
+            Self::List(cmd) => cmd.run(global_options).await,
+            Self::Update(cmd) => cmd.run(global_options).await,
         }
     }
 }
@@ -42,14 +47,17 @@ pub struct CreateCommand {
 }
 
 impl Command<CreateCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = CreateProductParams {
             organization_name: self.inner.organization_name,
             name: self.inner.name,
             delta_updatable: self.inner.delta_updatable,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api.products().create(params).await.context(ApiSnafu)? {
             Some(product) => print_json!(&product),
@@ -70,13 +78,16 @@ pub struct DeleteCommand {
 }
 
 impl Command<DeleteCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = DeleteProductParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         if (api.products().delete(params).await.context(ApiSnafu)?).is_some() {
             panic!()
@@ -96,13 +107,16 @@ pub struct GetCommand {
 }
 
 impl Command<GetCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = GetProductParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api.products().get(params).await.context(ApiSnafu)? {
             Some(product) => print_json!(&product),
@@ -120,12 +134,15 @@ pub struct ListCommand {
 }
 
 impl Command<ListCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = ListProductParams {
             organization_name: self.inner.organization_name,
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api.products().list(params).await.context(ApiSnafu)? {
             Some(product) => print_json!(&product),
@@ -152,7 +169,7 @@ pub struct UpdateCommand {
 }
 
 impl Command<UpdateCommand> {
-    async fn run(self) -> Result<(), Error> {
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         let params = UpdateProductParams {
             organization_name: self.inner.organization_name,
             product_name: self.inner.product_name,
@@ -162,7 +179,10 @@ impl Command<UpdateCommand> {
             },
         };
 
-        let api = Api::new(self.api_key, self.base_url);
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api.products().update(params).await.context(ApiSnafu)? {
             Some(product) => print_json!(&product),

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -1,6 +1,10 @@
 use super::Command;
-use crate::{print_json, ApiSnafu, Error};
+use crate::print_json;
+use crate::ApiSnafu;
+use crate::Error;
+use crate::GlobalOptions;
 use peridio_sdk::api::Api;
+use peridio_sdk::api::ApiOptions;
 use snafu::ResultExt;
 use structopt::StructOpt;
 
@@ -10,9 +14,9 @@ pub enum UsersCommand {
 }
 
 impl UsersCommand {
-    pub async fn run(self) -> Result<(), Error> {
+    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
         match self {
-            Self::Me(cmd) => cmd.run().await,
+            Self::Me(cmd) => cmd.run(global_options).await,
         }
     }
 }
@@ -21,8 +25,11 @@ impl UsersCommand {
 pub struct MeCommand {}
 
 impl Command<MeCommand> {
-    async fn run(self) -> Result<(), Error> {
-        let api = Api::new(self.api_key, self.base_url);
+    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+        let api = Api::new(ApiOptions {
+            api_key: global_options.api_key,
+            endpoint: global_options.base_url,
+        });
 
         match api.users().me().await.context(ApiSnafu)? {
             Some(users_me) => print_json!(&users_me),

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,14 +44,26 @@ impl fmt::Debug for Error {
 #[derive(StructOpt)]
 #[structopt(name = "peridio", version = env!("MOREL_VERSION"))]
 struct Program {
+    #[structopt(flatten)]
+    global_options: GlobalOptions,
+
     #[structopt(subcommand)]
     command: Command,
+}
+
+#[derive(StructOpt)]
+pub struct GlobalOptions {
+    #[structopt(long, env = "PERIDIO_API_KEY", hide_env_values = true)]
+    api_key: String,
+
+    #[structopt(long, env = "PERIDIO_BASE_URL")]
+    base_url: Option<String>,
 }
 
 impl Program {
     async fn run(self) -> Result<(), Error> {
         match self.command {
-            Command::Api(cmd) => cmd.run().await?,
+            Command::Api(cmd) => cmd.run(self.global_options).await?,
         };
 
         Ok(())


### PR DESCRIPTION
**Why**

- Avoid option conflicts between global and subcommand options.
- Reduce duplicative documentation downstream.

**How**

- Only accept global options in the top level peridio command.
- Stop accepting global options directly from every subcommand.