### PR TITLE
ENG-502: support supplying an organization via the environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,17 +77,39 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "06badb543e734a2d6568e19a40af66ed5364360b9226184926f89d229b4b4267"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -288,15 +301,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -559,6 +563,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,9 +599,10 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "peridio-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
+ "clap",
  "directories",
  "flate2",
  "futures-util",
@@ -601,8 +612,8 @@ dependencies = [
  "serde",
  "serde_json",
  "snafu",
- "structopt",
  "tar",
+ "termcolor",
  "tokio",
  "tower",
  "uuid",
@@ -611,7 +622,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=244de47#244de4706f041510641ca0678b44a0a6f62fae1d"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=ecdd1df#ecdd1df7c3e9b863f0135a982a4bb65a44c3e337"
 dependencies = [
  "chrono",
  "reqwest",
@@ -667,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -915,7 +926,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -939,33 +950,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -990,6 +977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,15 +993,6 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1192,12 +1179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,12 +1223,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1387,6 +1362,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,9 @@ version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "244de47" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "ecdd1df" }
 serde_json = "1.0"
 snafu = "0.7"
-structopt = "0.3"
 tokio = { version = "1.4", features = ["full"] }
 tower = {version = "0.4"}
 directories = "4.0.1"
@@ -22,3 +21,5 @@ flate2 = "1.0.24"
 tar = "0.4.38"
 uuid = {version = "1.1.2", features = ["v4", "fast-rng", "macro-diagnostics"]}
 base64 = "0.13.0"
+clap = {version = "4.0.17", features = ["derive", "env"]}
+termcolor = "1.1.3"

--- a/src/api/firmwares.rs
+++ b/src/api/firmwares.rs
@@ -2,17 +2,16 @@ use super::Command;
 use crate::print_json;
 use crate::ApiSnafu;
 use crate::Error;
-use crate::GlobalOptions;
+use clap::Parser;
 use peridio_sdk::api::firmwares::{
     CreateFirmwareParams, DeleteFirmwareParams, GetFirmwareParams, ListFirmwareParams,
 };
 use peridio_sdk::api::Api;
 use peridio_sdk::api::ApiOptions;
 use snafu::ResultExt;
-use structopt::StructOpt;
 use uuid::Uuid;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub enum FirmwaresCommand {
     Create(Command<CreateCommand>),
     Delete(Command<DeleteCommand>),
@@ -21,43 +20,41 @@ pub enum FirmwaresCommand {
 }
 
 impl FirmwaresCommand {
-    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    pub async fn run(self) -> Result<(), Error> {
         match self {
-            Self::Create(cmd) => cmd.run(global_options).await,
-            Self::Delete(cmd) => cmd.run(global_options).await,
-            Self::Get(cmd) => cmd.run(global_options).await,
-            Self::List(cmd) => cmd.run(global_options).await,
+            Self::Create(cmd) => cmd.run().await,
+            Self::Delete(cmd) => cmd.run().await,
+            Self::Get(cmd) => cmd.run().await,
+            Self::List(cmd) => cmd.run().await,
         }
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct CreateCommand {
-    #[structopt(long)]
+    #[arg(long)]
     firmware_path: String,
 
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 
-    #[structopt(long)]
+    #[arg(long)]
     ttl: Option<u32>,
 }
 
 impl Command<CreateCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = CreateFirmwareParams {
             firmware_path: self.inner.firmware_path,
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
             ttl: self.inner.ttl,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.firmwares().create(params).await.context(ApiSnafu)? {
@@ -69,29 +66,27 @@ impl Command<CreateCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct DeleteCommand {
-    #[structopt(long)]
+    #[arg(long)]
     firmware_uuid: Uuid,
 
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 }
 
 impl Command<DeleteCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = DeleteFirmwareParams {
             firmware_uuid: self.inner.firmware_uuid.to_string(),
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         if (api.firmwares().delete(params).await.context(ApiSnafu)?).is_some() {
@@ -102,29 +97,27 @@ impl Command<DeleteCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct GetCommand {
-    #[structopt(long)]
+    #[arg(long)]
     firmware_uuid: Uuid,
 
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 }
 
 impl Command<GetCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = GetFirmwareParams {
             firmware_uuid: self.inner.firmware_uuid.to_string(),
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.firmwares().get(params).await.context(ApiSnafu)? {
@@ -136,25 +129,23 @@ impl Command<GetCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct ListCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 }
 
 impl Command<ListCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = ListFirmwareParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.firmwares().list(params).await.context(ApiSnafu)? {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -9,42 +9,67 @@ mod signing_keys;
 mod upgrade;
 mod users;
 
-use crate::GlobalOptions;
-use structopt::StructOpt;
+use std::path::PathBuf;
 
-#[derive(StructOpt, Debug)]
-pub struct Command<T: StructOpt> {
-    #[structopt(flatten)]
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+pub struct Command<T>
+where
+    T: Parser + clap::Args,
+{
+    #[arg(from_global)]
+    api_key: String,
+
+    #[arg(from_global)]
+    base_url: Option<String>,
+
+    #[arg(from_global)]
+    ca_path: Option<PathBuf>,
+
+    #[arg(from_global)]
+    organization_name: String,
+
+    #[command(flatten)]
     inner: T,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(clap::Subcommand, Debug)]
 pub enum ApiCommand {
+    #[command(subcommand)]
     CaCertificates(ca_certificates::CaCertificatesCommand),
+    #[command(subcommand)]
     Deployments(deployments::DeploymentsCommand),
+    #[command(subcommand)]
     Devices(devices::DevicesCommand),
+    #[command(subcommand)]
     DeviceCertificates(device_certificates::DeviceCertificatesCommand),
+    #[command(subcommand)]
     Firmwares(firmwares::FirmwaresCommand),
+    #[command(subcommand)]
     Organizations(organization::OrganizationCommand),
+    #[command(subcommand)]
     Products(products::ProductsCommand),
+    #[command(subcommand)]
     SigningKeys(signing_keys::SigningKeysCommand),
-    #[structopt(flatten)]
+    #[command(args_conflicts_with_subcommands = true, subcommand_negates_reqs = true)]
     Upgrade(upgrade::UpgradeCommand),
+    #[command(subcommand)]
     Users(users::UsersCommand),
 }
 
 impl ApiCommand {
-    pub(crate) async fn run(self, global_options: GlobalOptions) -> Result<(), crate::Error> {
+    pub(crate) async fn run(self) -> Result<(), crate::Error> {
         match self {
-            ApiCommand::CaCertificates(cmd) => cmd.run(global_options).await?,
-            ApiCommand::Deployments(cmd) => cmd.run(global_options).await?,
-            ApiCommand::Devices(cmd) => cmd.run(global_options).await?,
-            ApiCommand::DeviceCertificates(cmd) => cmd.run(global_options).await?,
-            ApiCommand::Firmwares(cmd) => cmd.run(global_options).await?,
-            ApiCommand::Organizations(cmd) => cmd.run(global_options).await?,
-            ApiCommand::Products(cmd) => cmd.run(global_options).await?,
-            ApiCommand::SigningKeys(cmd) => cmd.run(global_options).await?,
-            ApiCommand::Users(cmd) => cmd.run(global_options).await?,
+            ApiCommand::CaCertificates(cmd) => cmd.run().await?,
+            ApiCommand::Deployments(cmd) => cmd.run().await?,
+            ApiCommand::Devices(cmd) => cmd.run().await?,
+            ApiCommand::DeviceCertificates(cmd) => cmd.run().await?,
+            ApiCommand::Firmwares(cmd) => cmd.run().await?,
+            ApiCommand::Organizations(cmd) => cmd.run().await?,
+            ApiCommand::Products(cmd) => cmd.run().await?,
+            ApiCommand::SigningKeys(cmd) => cmd.run().await?,
+            ApiCommand::Users(cmd) => cmd.run().await?,
             ApiCommand::Upgrade(cmd) => cmd.run().await?,
         };
 

--- a/src/api/organization.rs
+++ b/src/api/organization.rs
@@ -2,7 +2,7 @@ use super::Command;
 use crate::print_json;
 use crate::ApiSnafu;
 use crate::Error;
-use crate::GlobalOptions;
+use clap::Parser;
 use peridio_sdk::api::organization_users::{
     AddOrganizationUserParams, GetOrganizationUserParams, ListOrganizationUserParams,
     RemoveOrganizationUserParams, UpdateOrganizationUserParams,
@@ -10,9 +10,8 @@ use peridio_sdk::api::organization_users::{
 use peridio_sdk::api::Api;
 use peridio_sdk::api::ApiOptions;
 use snafu::ResultExt;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub enum OrganizationCommand {
     AddUser(Command<AddUserCommand>),
     RemoveUser(Command<RemoveUserCommand>),
@@ -22,40 +21,38 @@ pub enum OrganizationCommand {
 }
 
 impl OrganizationCommand {
-    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    pub async fn run(self) -> Result<(), Error> {
         match self {
-            Self::AddUser(cmd) => cmd.run(global_options).await,
-            Self::RemoveUser(cmd) => cmd.run(global_options).await,
-            Self::GetUser(cmd) => cmd.run(global_options).await,
-            Self::ListUsers(cmd) => cmd.run(global_options).await,
-            Self::UpdateUser(cmd) => cmd.run(global_options).await,
+            Self::AddUser(cmd) => cmd.run().await,
+            Self::RemoveUser(cmd) => cmd.run().await,
+            Self::GetUser(cmd) => cmd.run().await,
+            Self::ListUsers(cmd) => cmd.run().await,
+            Self::UpdateUser(cmd) => cmd.run().await,
         }
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct AddUserCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     role: String,
 
-    #[structopt(long)]
+    #[arg(long)]
     username: String,
 }
 
 impl Command<AddUserCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = AddOrganizationUserParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             role: self.inner.role,
             username: self.inner.username,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api
@@ -72,25 +69,23 @@ impl Command<AddUserCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct RemoveUserCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     user_username: String,
 }
 
 impl Command<RemoveUserCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = RemoveOrganizationUserParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             user_username: self.inner.user_username,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         if (api
@@ -107,25 +102,23 @@ impl Command<RemoveUserCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct GetUserCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     user_username: String,
 }
 
 impl Command<GetUserCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = GetOrganizationUserParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             user_username: self.inner.user_username,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api
@@ -142,21 +135,19 @@ impl Command<GetUserCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
-pub struct ListUsersCommand {
-    #[structopt(long)]
-    organization_name: String,
-}
+#[derive(Parser, Debug)]
+pub struct ListUsersCommand {}
 
 impl Command<ListUsersCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = ListOrganizationUserParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api
@@ -173,29 +164,27 @@ impl Command<ListUsersCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct UpdateUserCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     role: String,
 
-    #[structopt(long)]
+    #[arg(long)]
     user_username: String,
 }
 
 impl Command<UpdateUserCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = UpdateOrganizationUserParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             role: self.inner.role,
             user_username: self.inner.user_username,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api

--- a/src/api/products.rs
+++ b/src/api/products.rs
@@ -2,7 +2,7 @@ use super::Command;
 use crate::print_json;
 use crate::ApiSnafu;
 use crate::Error;
-use crate::GlobalOptions;
+use clap::Parser;
 use peridio_sdk::api::product_users::{
     AddProductUserParams, GetProductUserParams, ListProductUserParams, RemoveProductUserParams,
     UpdateProductUserParams,
@@ -15,9 +15,8 @@ use peridio_sdk::api::Api;
 use peridio_sdk::api::ApiOptions;
 use peridio_sdk::api::UpdateProduct;
 use snafu::ResultExt;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub enum ProductsCommand {
     Create(Command<CreateCommand>),
     Delete(Command<DeleteCommand>),
@@ -32,45 +31,43 @@ pub enum ProductsCommand {
 }
 
 impl ProductsCommand {
-    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    pub async fn run(self) -> Result<(), Error> {
         match self {
-            Self::Create(cmd) => cmd.run(global_options).await,
-            Self::Delete(cmd) => cmd.run(global_options).await,
-            Self::Get(cmd) => cmd.run(global_options).await,
-            Self::List(cmd) => cmd.run(global_options).await,
-            Self::Update(cmd) => cmd.run(global_options).await,
-            Self::AddUser(cmd) => cmd.run(global_options).await,
-            Self::RemoveUser(cmd) => cmd.run(global_options).await,
-            Self::GetUser(cmd) => cmd.run(global_options).await,
-            Self::ListUsers(cmd) => cmd.run(global_options).await,
-            Self::UpdateUser(cmd) => cmd.run(global_options).await,
+            Self::Create(cmd) => cmd.run().await,
+            Self::Delete(cmd) => cmd.run().await,
+            Self::Get(cmd) => cmd.run().await,
+            Self::List(cmd) => cmd.run().await,
+            Self::Update(cmd) => cmd.run().await,
+            Self::AddUser(cmd) => cmd.run().await,
+            Self::RemoveUser(cmd) => cmd.run().await,
+            Self::GetUser(cmd) => cmd.run().await,
+            Self::ListUsers(cmd) => cmd.run().await,
+            Self::UpdateUser(cmd) => cmd.run().await,
         }
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct CreateCommand {
-    #[structopt(long)]
+    #[arg(long)]
     delta_updatable: Option<bool>,
 
-    #[structopt(long)]
+    #[arg(long)]
     name: String,
-
-    #[structopt(long)]
-    organization_name: String,
 }
 
 impl Command<CreateCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = CreateProductParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             name: self.inner.name,
             delta_updatable: self.inner.delta_updatable,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.products().create(params).await.context(ApiSnafu)? {
@@ -82,25 +79,23 @@ impl Command<CreateCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct DeleteCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 }
 
 impl Command<DeleteCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = DeleteProductParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         if (api.products().delete(params).await.context(ApiSnafu)?).is_some() {
@@ -111,25 +106,23 @@ impl Command<DeleteCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct GetCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 }
 
 impl Command<GetCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = GetProductParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.products().get(params).await.context(ApiSnafu)? {
@@ -141,21 +134,19 @@ impl Command<GetCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
-pub struct ListCommand {
-    #[structopt(long)]
-    organization_name: String,
-}
+#[derive(Parser, Debug)]
+pub struct ListCommand {}
 
 impl Command<ListCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = ListProductParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.products().list(params).await.context(ApiSnafu)? {
@@ -167,25 +158,22 @@ impl Command<ListCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct UpdateCommand {
-    #[structopt(long)]
+    #[arg(long)]
     delta_updatable: Option<bool>,
 
-    #[structopt(long)]
+    #[arg(long)]
     name: Option<String>,
 
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 }
 
 impl Command<UpdateCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = UpdateProductParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
             product: UpdateProduct {
                 delta_updatable: self.inner.delta_updatable,
@@ -194,8 +182,9 @@ impl Command<UpdateCommand> {
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.products().update(params).await.context(ApiSnafu)? {
@@ -207,33 +196,31 @@ impl Command<UpdateCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct AddUserCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 
-    #[structopt(long)]
+    #[arg(long)]
     role: String,
 
-    #[structopt(long)]
+    #[arg(long)]
     username: String,
 }
 
 impl Command<AddUserCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = AddProductUserParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
             role: self.inner.role,
             username: self.inner.username,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.product_users().add(params).await.context(ApiSnafu)? {
@@ -245,29 +232,27 @@ impl Command<AddUserCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct RemoveUserCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 
-    #[structopt(long)]
+    #[arg(long)]
     user_username: String,
 }
 
 impl Command<RemoveUserCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = RemoveProductUserParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
             user_username: self.inner.user_username,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         if (api.product_users().remove(params).await.context(ApiSnafu)?).is_some() {
@@ -278,29 +263,27 @@ impl Command<RemoveUserCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct GetUserCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 
-    #[structopt(long)]
+    #[arg(long)]
     user_username: String,
 }
 
 impl Command<GetUserCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = GetProductUserParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
             user_username: self.inner.user_username,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.product_users().get(params).await.context(ApiSnafu)? {
@@ -312,25 +295,23 @@ impl Command<GetUserCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct ListUsersCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 }
 
 impl Command<ListUsersCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = ListProductUserParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.product_users().list(params).await.context(ApiSnafu)? {
@@ -342,33 +323,31 @@ impl Command<ListUsersCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct UpdateUserCommand {
-    #[structopt(long)]
-    organization_name: String,
-
-    #[structopt(long)]
+    #[arg(long)]
     product_name: String,
 
-    #[structopt(long)]
+    #[arg(long)]
     role: String,
 
-    #[structopt(long)]
+    #[arg(long)]
     user_username: String,
 }
 
 impl Command<UpdateUserCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = UpdateProductUserParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
             product_name: self.inner.product_name,
             role: self.inner.role,
             user_username: self.inner.user_username,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.product_users().update(params).await.context(ApiSnafu)? {

--- a/src/api/signing_keys.rs
+++ b/src/api/signing_keys.rs
@@ -2,14 +2,13 @@ use super::Command;
 use crate::print_json;
 use crate::ApiSnafu;
 use crate::Error;
-use crate::GlobalOptions;
+use clap::Parser;
 use peridio_sdk::api::signing_keys::{CreateParams, DeleteParams, GetParams, ListParams};
 use peridio_sdk::api::Api;
 use peridio_sdk::api::ApiOptions;
 use snafu::ResultExt;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub enum SigningKeysCommand {
     Create(Command<CreateCommand>),
     Delete(Command<DeleteCommand>),
@@ -18,39 +17,37 @@ pub enum SigningKeysCommand {
 }
 
 impl SigningKeysCommand {
-    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    pub async fn run(self) -> Result<(), Error> {
         match self {
-            Self::Create(cmd) => cmd.run(global_options).await,
-            Self::Delete(cmd) => cmd.run(global_options).await,
-            Self::Get(cmd) => cmd.run(global_options).await,
-            Self::List(cmd) => cmd.run(global_options).await,
+            Self::Create(cmd) => cmd.run().await,
+            Self::Delete(cmd) => cmd.run().await,
+            Self::Get(cmd) => cmd.run().await,
+            Self::List(cmd) => cmd.run().await,
         }
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct CreateCommand {
-    #[structopt(long)]
+    #[arg(long)]
     key: String,
 
-    #[structopt(long)]
+    #[arg(long)]
     name: String,
-
-    #[structopt(long)]
-    organization_name: String,
 }
 
 impl Command<CreateCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = CreateParams {
             key: self.inner.key,
             name: self.inner.name,
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.signing_keys().create(params).await.context(ApiSnafu)? {
@@ -62,25 +59,23 @@ impl Command<CreateCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct DeleteCommand {
-    #[structopt(long)]
+    #[arg(long)]
     name: String,
-
-    #[structopt(long)]
-    organization_name: String,
 }
 
 impl Command<DeleteCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = DeleteParams {
             name: self.inner.name,
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         if (api.signing_keys().delete(params).await.context(ApiSnafu)?).is_some() {
@@ -91,25 +86,23 @@ impl Command<DeleteCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct GetCommand {
-    #[structopt(long)]
+    #[arg(long)]
     name: String,
-
-    #[structopt(long)]
-    organization_name: String,
 }
 
 impl Command<GetCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = GetParams {
             name: self.inner.name,
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.signing_keys().get(params).await.context(ApiSnafu)? {
@@ -121,21 +114,19 @@ impl Command<GetCommand> {
     }
 }
 
-#[derive(StructOpt, Debug)]
-pub struct ListCommand {
-    #[structopt(long)]
-    organization_name: String,
-}
+#[derive(Parser, Debug)]
+pub struct ListCommand {}
 
 impl Command<ListCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let params = ListParams {
-            organization_name: self.inner.organization_name,
+            organization_name: self.organization_name,
         };
 
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.signing_keys().list(params).await.context(ApiSnafu)? {

--- a/src/api/upgrade.rs
+++ b/src/api/upgrade.rs
@@ -6,13 +6,13 @@ use std::{
     path::Path,
 };
 
+use clap::Parser;
 use directories::ProjectDirs;
 use flate2::read::GzDecoder;
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::ClientBuilder;
 use serde::Deserialize;
-use structopt::StructOpt;
 use tar::Archive;
 
 use crate::Error;
@@ -28,27 +28,14 @@ struct GithubResponse {
     assets: Vec<GithubAssetResponse>,
 }
 
-#[derive(StructOpt, Debug)]
-pub enum UpgradeCommand {
-    Upgrade(DoUpgradeCommand),
+#[derive(Parser, Debug)]
+pub struct UpgradeCommand {
+    #[arg(long)]
+    version: Option<String>,
 }
 
 impl UpgradeCommand {
     pub async fn run(self) -> Result<(), Error> {
-        match self {
-            Self::Upgrade(cmd) => cmd.run().await,
-        }
-    }
-}
-
-#[derive(StructOpt, Debug)]
-pub struct DoUpgradeCommand {
-    #[structopt(long)]
-    version: Option<String>,
-}
-
-impl DoUpgradeCommand {
-    async fn run(self) -> Result<(), Error> {
         if let Some(proj_dirs) = ProjectDirs::from("com", "peridio", "peridio cli") {
             let cache_dir = proj_dirs.cache_dir();
 

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -2,33 +2,33 @@ use super::Command;
 use crate::print_json;
 use crate::ApiSnafu;
 use crate::Error;
-use crate::GlobalOptions;
+use clap::Parser;
 use peridio_sdk::api::Api;
 use peridio_sdk::api::ApiOptions;
 use snafu::ResultExt;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub enum UsersCommand {
     Me(Command<MeCommand>),
 }
 
 impl UsersCommand {
-    pub async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    pub async fn run(self) -> Result<(), Error> {
         match self {
-            Self::Me(cmd) => cmd.run(global_options).await,
+            Self::Me(cmd) => cmd.run().await,
         }
     }
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct MeCommand {}
 
 impl Command<MeCommand> {
-    async fn run(self, global_options: GlobalOptions) -> Result<(), Error> {
+    async fn run(self) -> Result<(), Error> {
         let api = Api::new(ApiOptions {
-            api_key: global_options.api_key,
-            endpoint: global_options.base_url,
+            api_key: self.api_key,
+            endpoint: self.base_url,
+            ca_bundle_path: self.ca_path,
         });
 
         match api.users().me().await.context(ApiSnafu)? {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,13 @@
 mod api;
 
-use std::{fmt, io, path};
+use std::{
+    fmt,
+    io::{self, ErrorKind},
+    path::{self, PathBuf},
+};
 
+use clap::Parser;
 use snafu::Snafu;
-use structopt::StructOpt;
 
 #[macro_export]
 #[allow(clippy::crate_in_macro_def)]
@@ -33,6 +37,12 @@ pub enum Error {
 
     #[snafu(display("Unable to retrieve file metadata {:?}", source))]
     FileMetadata { source: io::Error },
+
+    #[snafu(display("{:?}", path))]
+    NonExistingPath {
+        path: path::PathBuf,
+        source: io::Error,
+    },
 }
 
 impl fmt::Debug for Error {
@@ -41,47 +51,97 @@ impl fmt::Debug for Error {
     }
 }
 
-#[derive(StructOpt)]
-#[structopt(name = "peridio", version = env!("MOREL_VERSION"))]
+#[derive(Parser)]
+#[command(name = "peridio", version = env!("MOREL_VERSION"))]
 struct Program {
-    #[structopt(flatten)]
+    #[command(flatten)]
     global_options: GlobalOptions,
 
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     command: Command,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct GlobalOptions {
-    #[structopt(long, env = "PERIDIO_API_KEY", hide_env_values = true)]
-    api_key: String,
+    #[arg(long, env = "PERIDIO_API_KEY", hide_env_values = true, global = true)]
+    api_key: Option<String>,
 
-    #[structopt(long, env = "PERIDIO_BASE_URL")]
+    #[arg(long, env = "PERIDIO_BASE_URL", global = true)]
     base_url: Option<String>,
+
+    #[arg(long, env = "PERIDIO_CA_PATH", global = true)]
+    ca_path: Option<PathBuf>,
+
+    #[arg(long, env = "PERIDIO_ORGANIZATION_NAME", global = true)]
+    organization_name: Option<String>,
 }
 
 impl Program {
     async fn run(self) -> Result<(), Error> {
+        if let Some(path) = self.global_options.ca_path {
+            if !path.exists() {
+                return Err(Error::NonExistingPath {
+                    path,
+                    source: std::io::Error::from(ErrorKind::NotFound),
+                });
+            }
+        }
+
         match self.command {
-            Command::Api(cmd) => cmd.run(self.global_options).await?,
+            Command::Api(cmd) => cmd.run().await?,
         };
 
         Ok(())
     }
 }
 
-#[derive(StructOpt)]
-#[structopt(about = "Work with Peridio from the command line.")]
+#[derive(Parser)]
+#[command(about = "Work with Peridio from the command line.")]
 enum Command {
-    #[structopt(flatten)]
+    #[command(flatten)]
     Api(api::ApiCommand),
 }
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = Program::from_args().run().await {
+    if let Err(e) = Program::parse().run().await {
         match e {
-            Error::Api { source } => eprintln!("{}", source),
+            Error::Api { source } => {
+                eprintln!("{}", source)
+            }
+
+            Error::NonExistingPath { path, source: _ } => {
+                use std::io::Write;
+                use termcolor::WriteColor;
+
+                let bufwtr = termcolor::BufferWriter::stderr(termcolor::ColorChoice::Always);
+                let mut buffer = bufwtr.buffer();
+
+                buffer
+                    .set_color(
+                        termcolor::ColorSpec::new()
+                            .set_fg(Some(termcolor::Color::Red))
+                            .set_bold(true),
+                    )
+                    .unwrap();
+
+                write!(&mut buffer, "error: ").unwrap();
+
+                buffer.set_color(&termcolor::ColorSpec::new()).unwrap();
+
+                writeln!(&mut buffer, "Path does not exist:").unwrap();
+
+                buffer
+                    .set_color(termcolor::ColorSpec::new().set_fg(Some(termcolor::Color::Yellow)))
+                    .unwrap();
+
+                writeln!(&mut buffer, "\t{}", path.display()).unwrap();
+
+                bufwtr.print(&buffer).unwrap();
+
+                // DATAERR
+                std::process::exit(65);
+            }
 
             error => eprintln!("Error: {}", error),
         }


### PR DESCRIPTION
Related:

ENG-501: support --ca-path PATH
ENG-505: improve error when failing to open a file or directory
ENG-504: do not require an API key for the peridio upgrade command

Why:

We want to allow for `organization-name` to be available as a global option.