### PR TITLE
ENG-516: move delta updates to deployments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,7 +622,7 @@ dependencies = [
 [[package]]
 name = "peridio-sdk"
 version = "0.1.0"
-source = "git+ssh://git@github.com/peridio/reishi.git?rev=ecdd1df#ecdd1df7c3e9b863f0135a982a4bb65a44c3e337"
+source = "git+ssh://git@github.com/peridio/reishi.git?rev=1a6ad07#1a6ad075d2e70ae42b6e9d3e07ba74e1eca83e7b"
 dependencies = [
  "chrono",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "ecdd1df" }
+peridio-sdk = { git = "ssh://git@github.com/peridio/reishi.git", rev = "1a6ad07" }
 serde_json = "1.0"
 snafu = "0.7"
 tokio = { version = "1.4", features = ["full"] }

--- a/src/api/deployments.rs
+++ b/src/api/deployments.rs
@@ -41,6 +41,9 @@ impl DeploymentsCommand {
 #[derive(Parser, Debug)]
 pub struct CreateCommand {
     #[arg(long)]
+    delta_updatable: Option<bool>,
+
+    #[arg(long)]
     firmware: Uuid,
 
     #[arg(long)]
@@ -68,6 +71,7 @@ impl Command<CreateCommand> {
                 tags: self.inner.tags,
                 version: self.inner.version,
             },
+            delta_updatable: self.inner.delta_updatable,
         };
 
         let api = Api::new(ApiOptions {
@@ -179,6 +183,9 @@ impl Command<ListCommand> {
 #[derive(Parser, Debug)]
 pub struct UpdateCommand {
     #[arg(long)]
+    delta_updatable: Option<bool>,
+
+    #[arg(long)]
     deployment_name: String,
 
     #[arg(long)]
@@ -224,6 +231,7 @@ impl Command<UpdateCommand> {
             },
             firmware,
             is_active: self.inner.is_active,
+            delta_updatable: self.inner.delta_updatable,
         };
 
         let params = UpdateDeploymentParams {

--- a/src/api/products.rs
+++ b/src/api/products.rs
@@ -51,9 +51,6 @@ impl ProductsCommand {
 #[derive(Parser, Debug)]
 pub struct CreateCommand {
     #[arg(long)]
-    delta_updatable: Option<bool>,
-
-    #[arg(long)]
     name: String,
 }
 
@@ -62,7 +59,6 @@ impl Command<CreateCommand> {
         let params = CreateProductParams {
             organization_name: global_options.organization_name.unwrap(),
             name: self.inner.name,
-            delta_updatable: self.inner.delta_updatable,
         };
 
         let api = Api::new(ApiOptions {
@@ -162,9 +158,6 @@ impl Command<ListCommand> {
 #[derive(Parser, Debug)]
 pub struct UpdateCommand {
     #[arg(long)]
-    delta_updatable: Option<bool>,
-
-    #[arg(long)]
     name: Option<String>,
 
     #[arg(long)]
@@ -177,7 +170,6 @@ impl Command<UpdateCommand> {
             organization_name: global_options.organization_name.unwrap(),
             product_name: self.inner.product_name,
             product: UpdateProduct {
-                delta_updatable: self.inner.delta_updatable,
                 name: self.inner.name,
             },
         };


### PR DESCRIPTION
Why:

We want to update our SDK to the latest changes for delta updates.