### PR TITLE
ENG-535: fix failed clippy check

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 fn main() {
     // This is ran only during build process, we expect to always have git when building the app
     let output = Command::new("git")
-        .args(&["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short", "HEAD"])
         .output()
         .unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();

--- a/src/api/deployments.rs
+++ b/src/api/deployments.rs
@@ -218,7 +218,7 @@ impl Command<UpdateCommand> {
 
         let deployment = UpdateDeployment {
             name: self.inner.name,
-            conditions: if self.inner.tags != None || self.inner.version != None {
+            conditions: if self.inner.tags.is_some() || self.inner.version.is_some() {
                 let tags = self.inner.tags;
                 let version = self.inner.version;
 

--- a/src/api/upgrade.rs
+++ b/src/api/upgrade.rs
@@ -140,7 +140,7 @@ impl UpgradeCommand {
         let mut archive = Archive::new(gz);
 
         archive
-            .unpack(&download_path)
+            .unpack(download_path)
             .map_err(|_| "Error while saving the updated file".to_string())?;
 
         Ok(())


### PR DESCRIPTION
Why:

Fixes issues with newer versions of rust Clippy