### PR TITLE
ENG-616: multi-target support for upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,7 +599,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "peridio-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "clap",

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::process::Command;
 
 fn main() {
@@ -12,4 +13,5 @@ fn main() {
         env!("CARGO_PKG_VERSION"),
         git_hash
     );
+    println!("cargo:rustc-env=TARGET={}", env::var("TARGET").unwrap());
 }


### PR DESCRIPTION
**Why**

CI for Morel is planned to provide pre-built binaries for multiple targets instead of just for one.

**How**

Make the upgrade command resolve the release binary that matches its current build target instead of grabbing the first available asset.